### PR TITLE
[Transformer] transform method could accept any kind of $data

### DIFF
--- a/src/Knp/ETL/Transformer/CallbackTransformer.php
+++ b/src/Knp/ETL/Transformer/CallbackTransformer.php
@@ -14,7 +14,7 @@ class CallbackTransformer implements TransformerInterface
         $this->callback = $callback;
     }
 
-    public function transform(array $data, ContextInterface $context)
+    public function transform($data, ContextInterface $context)
     {
         $target = $context->getTransformedData();
 

--- a/src/Knp/ETL/Transformer/DataMap.php
+++ b/src/Knp/ETL/Transformer/DataMap.php
@@ -42,7 +42,7 @@ class DataMap implements TransformerInterface
         }
     }
 
-    public function transform(array $data, ContextInterface $context)
+    public function transform($data, ContextInterface $context)
     {
         $target = $context->getTransformedData();
 

--- a/src/Knp/ETL/Transformer/Doctrine/ObjectTransformer.php
+++ b/src/Knp/ETL/Transformer/Doctrine/ObjectTransformer.php
@@ -23,7 +23,7 @@ class ObjectTransformer implements TransformerInterface
         $this->doctrine = $doctrine;
     }
 
-    public function transform(array $data, ContextInterface $context)
+    public function transform($data, ContextInterface $context)
     {
         $this->mapper->verifyCount($data);
 

--- a/src/Knp/ETL/TransformerInterface.php
+++ b/src/Knp/ETL/TransformerInterface.php
@@ -10,10 +10,10 @@ interface TransformerInterface
     /**
      * transforms array data into specific representation
      *
-     * @param array $data the extracted data to transform
+     * @param mixed $data the extracted data to transform
      *
      * @return mixed the transformed data
      */
-    function transform(array $data, ContextInterface $context);
+    function transform($data, ContextInterface $context);
 }
 


### PR DESCRIPTION
As discuss in issue #12 remove the type hinting array as we could transform other kind of data.

Each transformer should validate its `$data` parameter.
