### PR TITLE
Improved monolog usage

### DIFF
--- a/src/Knp/ETL/Extractor/CsvExtractor.php
+++ b/src/Knp/ETL/Extractor/CsvExtractor.php
@@ -2,6 +2,7 @@
 
 namespace Knp\ETL\Extractor;
 
+use Psr\Log\NullLogger;
 use Symfony\Component\Finder\Finder;
 
 use Knp\ETL\ExtractorInterface;
@@ -22,9 +23,9 @@ class CsvExtractor implements ExtractorInterface, \Iterator, \Countable
 
     public function __construct($filename, $delimiter = ';', $enclosure = '"', $identifierColumn = null)
     {
-        if (null !== $this->logger) {
-            $this->logger->debug('extracting from: '.$filename);
-        }
+        $this->logger = new NullLogger();
+        // @todo don't log when the logger is not really yet injected (or inject logger directly in constructor)
+        $this->logger->debug('Extracting CSV', ['filepath' => $filename]);
 
         $this->csv = new \SplFileObject($filename);
         $this->csv->setFlags(\SplFileObject::READ_CSV);
@@ -62,9 +63,7 @@ class CsvExtractor implements ExtractorInterface, \Iterator, \Countable
     public function next()
     {
         $next = $this->csv->next();
-        if (null !== $this->logger) {
-            $this->logger->debug(sprintf('%s:%d', $this->csv->getBaseName(), $this->key()));
-        }
+        $this->logger->debug('Next csv element', ['name' => $this->csv->getBaseName(), 'value' => $this->key()]);
 
         return $next;
     }

--- a/src/Knp/ETL/Extractor/CsvExtractor.php
+++ b/src/Knp/ETL/Extractor/CsvExtractor.php
@@ -2,11 +2,9 @@
 
 namespace Knp\ETL\Extractor;
 
+use Psr\Log\LoggerInterface;
 use Psr\Log\NullLogger;
-use Symfony\Component\Finder\Finder;
-
 use Knp\ETL\ExtractorInterface;
-use Psr\Log\LoggerAwareTrait;
 use Knp\ETL\ContextInterface;
 
 /**
@@ -15,16 +13,14 @@ use Knp\ETL\ContextInterface;
  */
 class CsvExtractor implements ExtractorInterface, \Iterator, \Countable
 {
-    use LoggerAwareTrait;
-
     private $csv;
     private $identifierColumn;
     private $nbLines;
+    private $logger;
 
-    public function __construct($filename, $delimiter = ';', $enclosure = '"', $identifierColumn = null)
+    public function __construct($filename, $delimiter = ';', $enclosure = '"', $identifierColumn = null, LoggerInterface $logger = null)
     {
-        $this->logger = new NullLogger();
-        // @todo don't log when the logger is not really yet injected (or inject logger directly in constructor)
+        $this->logger = $logger ?: new NullLogger();
         $this->logger->debug('Extracting CSV', ['filepath' => $filename]);
 
         $this->csv = new \SplFileObject($filename);

--- a/src/Knp/ETL/Extractor/Doctrine/ORMExtractor.php
+++ b/src/Knp/ETL/Extractor/Doctrine/ORMExtractor.php
@@ -4,7 +4,7 @@ namespace Knp\ETL\Extractor\Doctrine;
 
 use Knp\ETL\ContextInterface;
 use Knp\ETL\ExtractorInterface;
-use Psr\Log\LoggerAwareTrait;
+use Psr\Log\LoggerInterface;
 use Psr\Log\NullLogger;
 
 /**
@@ -12,18 +12,16 @@ use Psr\Log\NullLogger;
  */
 class ORMExtractor implements ExtractorInterface, \Iterator
 {
-    use LoggerAwareTrait;
-
     private $query;
-
+    private $logger;
     protected $iterator;
 
     /**
      * Could be a Query or a QueryBuilder
      */
-    public function __construct($query)
+    public function __construct($query, LoggerInterface $logger = null)
     {
-        $this->logger = new NullLogger();
+        $this->logger = $logger ?: new NullLogger();
         $this->query = $query;
     }
 

--- a/src/Knp/ETL/Extractor/Doctrine/ORMExtractor.php
+++ b/src/Knp/ETL/Extractor/Doctrine/ORMExtractor.php
@@ -5,6 +5,7 @@ namespace Knp\ETL\Extractor\Doctrine;
 use Knp\ETL\ContextInterface;
 use Knp\ETL\ExtractorInterface;
 use Psr\Log\LoggerAwareTrait;
+use Psr\Log\NullLogger;
 
 /**
  * @author Timothée Barray <tim@amicalement-web.net>
@@ -22,6 +23,7 @@ class ORMExtractor implements ExtractorInterface, \Iterator
      */
     public function __construct($query)
     {
+        $this->logger = new NullLogger();
         $this->query = $query;
     }
 
@@ -51,10 +53,7 @@ class ORMExtractor implements ExtractorInterface, \Iterator
     public function next()
     {
         $next = $this->getIterator()->next();
-
-        if (null !== $this->logger) {
-            $this->logger->debug($this->getQuery()->getSql());
-        }
+        $this->logger->debug('Next SQL', ['sql' => $this->getQuery()->getSql()]);
 
         return $next;
     }

--- a/src/Knp/ETL/Extractor/ExcelExtractor.php
+++ b/src/Knp/ETL/Extractor/ExcelExtractor.php
@@ -7,6 +7,7 @@ use Psr\Log\LoggerAwareTrait;
 
 use Knp\ETL\ContextInterface;
 use Knp\ETL\ExtractorInterface;
+use Psr\Log\NullLogger;
 
 /**
  * @author Kévin Gomez <contact@kevingomez.fr>
@@ -22,9 +23,9 @@ class ExcelExtractor implements ExtractorInterface, \Iterator, \Countable
 
     public function __construct($filename, $identifierColumn = null, $headerRowNumber = 1, $activeSheet = null)
     {
-        if (null !== $this->logger) {
-            $this->logger->debug('extracting from: '.$filename);
-        }
+        $this->logger = new NullLogger();
+        // @todo don't log when the logger is not really yet injected (or inject logger directly in constructor)
+        $this->logger->debug('Extracting Excel', ['filename' => $filename]);
 
         $excel = PHPExcel_IOFactory::load($filename);
 
@@ -81,9 +82,7 @@ class ExcelExtractor implements ExtractorInterface, \Iterator, \Countable
     public function next()
     {
         $next = $this->worksheetIterator->next();
-        if (null !== $this->logger) {
-            $this->logger->debug(sprintf('%d', $this->key()));
-        }
+        $this->logger->debug('Next Excel element', ['key' => $this->key()]);
 
         return $next;
     }

--- a/src/Knp/ETL/Extractor/ExcelExtractor.php
+++ b/src/Knp/ETL/Extractor/ExcelExtractor.php
@@ -3,10 +3,9 @@
 namespace Knp\ETL\Extractor;
 
 use PHPExcel_IOFactory;
-use Psr\Log\LoggerAwareTrait;
-
 use Knp\ETL\ContextInterface;
 use Knp\ETL\ExtractorInterface;
+use Psr\Log\LoggerInterface;
 use Psr\Log\NullLogger;
 
 /**
@@ -14,17 +13,15 @@ use Psr\Log\NullLogger;
  */
 class ExcelExtractor implements ExtractorInterface, \Iterator, \Countable
 {
-    use LoggerAwareTrait;
-
     protected $worksheetIterator;
     protected $identifierColumn;
     protected $nbLines;
     protected $headerRowNumber = 1;
+    protected $logger;
 
-    public function __construct($filename, $identifierColumn = null, $headerRowNumber = 1, $activeSheet = null)
+    public function __construct($filename, $identifierColumn = null, $headerRowNumber = 1, $activeSheet = null, LoggerInterface $logger = null)
     {
-        $this->logger = new NullLogger();
-        // @todo don't log when the logger is not really yet injected (or inject logger directly in constructor)
+        $this->logger = $logger ?: new NullLogger();
         $this->logger->debug('Extracting Excel', ['filename' => $filename]);
 
         $excel = PHPExcel_IOFactory::load($filename);

--- a/src/Knp/ETL/Extractor/JsonExtractor.php
+++ b/src/Knp/ETL/Extractor/JsonExtractor.php
@@ -6,6 +6,7 @@ use Knp\ETL\ExtractorInterface;
 use Knp\ETL\ContextInterface;
 
 use Psr\Log\LoggerAwareTrait;
+use Psr\Log\NullLogger;
 
 /**
  * @author Timothée Barray <tim@amicalement-web.net>
@@ -39,9 +40,9 @@ class JsonExtractor implements ExtractorInterface, \Iterator, \Countable
      */
     public function __construct($resource, $path = null, \Closure $adapter = null)
     {
-        if (null !== $this->logger) {
-            $this->logger->debug('extracting from: '.$resource);
-        }
+        $this->logger = new NullLogger();
+        // @todo don't log when the logger is not really yet injected (or inject logger directly in constructor)
+        $this->logger->debug('Extracting JSON', ['path' => $resource]);
 
         $this->resource = $resource;
         $this->adapter = $adapter;
@@ -77,9 +78,7 @@ class JsonExtractor implements ExtractorInterface, \Iterator, \Countable
     public function next()
     {
         $next = $this->getIterator()->next();
-        if (null !== $this->logger) {
-            $this->logger->debug(sprintf('%s:%d', $this->resource, $this->key()));
-        }
+        $this->logger->debug('Next JSON element', ['path' => $this->resource, 'key' => $this->key()]);
 
         return $next;
     }

--- a/src/Knp/ETL/Extractor/JsonExtractor.php
+++ b/src/Knp/ETL/Extractor/JsonExtractor.php
@@ -4,8 +4,7 @@ namespace Knp\ETL\Extractor;
 
 use Knp\ETL\ExtractorInterface;
 use Knp\ETL\ContextInterface;
-
-use Psr\Log\LoggerAwareTrait;
+use Psr\Log\LoggerInterface;
 use Psr\Log\NullLogger;
 
 /**
@@ -13,13 +12,12 @@ use Psr\Log\NullLogger;
  */
 class JsonExtractor implements ExtractorInterface, \Iterator, \Countable
 {
-    use LoggerAwareTrait;
-
     private $json;
     private $identifierColumn;
     private $resource;
     private $adapter;
     private $path;
+    private $logger;
 
     /**
      * Regarding the following json structure :
@@ -37,11 +35,11 @@ class JsonExtractor implements ExtractorInterface, \Iterator, \Countable
      * @param string $resource Filename or URL for the json file
      * @param string $path The path in json file to go to your target nodes. Example : "nodes.*.node"
      * @param Closure $adapter A closure which wraps the way to get the content of json file
+     * @param LoggerInterface $logger The logger instance
      */
-    public function __construct($resource, $path = null, \Closure $adapter = null)
+    public function __construct($resource, $path = null, \Closure $adapter = null, LoggerInterface $logger = null)
     {
-        $this->logger = new NullLogger();
-        // @todo don't log when the logger is not really yet injected (or inject logger directly in constructor)
+        $this->logger = $logger ?: new NullLogger();
         $this->logger->debug('Extracting JSON', ['path' => $resource]);
 
         $this->resource = $resource;

--- a/src/Knp/ETL/Extractor/OrderedCsvExtractor.php
+++ b/src/Knp/ETL/Extractor/OrderedCsvExtractor.php
@@ -2,8 +2,6 @@
 
 namespace Knp\ETL\Extractor;
 
-use Symfony\Component\HttpKernel\Log\LoggerInterface;
-
 use Symfony\Component\Finder\Finder;
 
 use Knp\ETL\ExtractorInterface;

--- a/src/Knp/ETL/Loader/CsvLoader.php
+++ b/src/Knp/ETL/Loader/CsvLoader.php
@@ -9,10 +9,7 @@ class CsvLoader extends FileLoader
     public function load($data, ContextInterface $context)
     {
         $r = $this->file->fputcsv($data);
-
-        if (null !== $this->logger) {
-            $this->logger->debug(sprintf('Wrote %s bytes in %s', $r, $this->file->getBasename()));
-        }
+        $this->logger->debug('Write a field array as a CSV line', ['data' => $data, 'filename' => $this->file->getBasename(), 'bytes' => $r]);
 
         return $r;
     }

--- a/src/Knp/ETL/Loader/Doctrine/ORMLoader.php
+++ b/src/Knp/ETL/Loader/Doctrine/ORMLoader.php
@@ -7,6 +7,7 @@ use Doctrine\Common\Persistence\ManagerRegistry;
 use Knp\ETL\ContextInterface;
 use Knp\ETL\Context\Doctrine\ORMContext;
 use Knp\ETL\LoaderInterface;
+use Psr\Log\NullLogger;
 
 class ORMLoader implements LoaderInterface
 {
@@ -21,6 +22,7 @@ class ORMLoader implements LoaderInterface
     {
         $this->doctrine = $doctrine;
         $this->flushEvery = $flushEvery;
+        $this->logger = new NullLogger();
     }
 
     public function load($entity, ContextInterface $context)
@@ -54,17 +56,13 @@ class ORMLoader implements LoaderInterface
     public function flush(ContextInterface $context)
     {
         $this->doctrine->getManager()->flush();
-        if (null !== $this->logger) {
-            $this->logger->debug(sprintf('flush after %d persist hits', $this->counter));
-        }
+        $this->logger->debug('Doctrine flush', ['persist_hits' => $this->counter]);
     }
 
     public function clear(ContextInterface $context)
     {
         $this->doctrine->getManager()->clear($this->entityClass);
-        if (null !== $this->logger) {
-            $this->logger->debug(sprintf('clear after %d persist hits', $this->counter));
-        }
+        $this->logger->debug('Doctrine clean', ['persist_hits' => $this->counter]);
     }
 }
 

--- a/src/Knp/ETL/Loader/Doctrine/ORMLoader.php
+++ b/src/Knp/ETL/Loader/Doctrine/ORMLoader.php
@@ -2,27 +2,26 @@
 
 namespace Knp\ETL\Loader\Doctrine;
 
-use Psr\Log\LoggerAwareTrait;
 use Doctrine\Common\Persistence\ManagerRegistry;
 use Knp\ETL\ContextInterface;
 use Knp\ETL\Context\Doctrine\ORMContext;
 use Knp\ETL\LoaderInterface;
+use Psr\Log\LoggerInterface;
 use Psr\Log\NullLogger;
 
 class ORMLoader implements LoaderInterface
 {
-    use LoggerAwareTrait;
-
     private $counter = 0;
     private $flushEvery;
     private $doctrine;
     private $entityClass;
+    private $logger;
 
-    public function __construct(ManagerRegistry $doctrine, $flushEvery = 100)
+    public function __construct(ManagerRegistry $doctrine, $flushEvery = 100, LoggerInterface $logger = null)
     {
         $this->doctrine = $doctrine;
         $this->flushEvery = $flushEvery;
-        $this->logger = new NullLogger();
+        $this->logger = $logger ?: new NullLogger();
     }
 
     public function load($entity, ContextInterface $context)

--- a/src/Knp/ETL/Loader/FileLoader.php
+++ b/src/Knp/ETL/Loader/FileLoader.php
@@ -1,21 +1,20 @@
 <?php
 namespace Knp\ETL\Loader;
 
-use Psr\Log\LoggerAwareTrait;
 use Knp\ETL\ContextInterface;
 use Knp\ETL\LoaderInterface;
+use Psr\Log\LoggerInterface;
 use Psr\Log\NullLogger;
 use SplFileObject;
 
 class FileLoader implements LoaderInterface
 {
-    use LoggerAwareTrait;
-
     protected $file;
+    protected $logger;
 
-    public function __construct(SplFileObject $file)
+    public function __construct(SplFileObject $file, LoggerInterface $logger = null)
     {
-        $this->logger = new NullLogger();
+        $this->logger = $logger ?: new NullLogger();
         $this->file = $file;
     }
 

--- a/src/Knp/ETL/Loader/FileLoader.php
+++ b/src/Knp/ETL/Loader/FileLoader.php
@@ -4,6 +4,7 @@ namespace Knp\ETL\Loader;
 use Psr\Log\LoggerAwareTrait;
 use Knp\ETL\ContextInterface;
 use Knp\ETL\LoaderInterface;
+use Psr\Log\NullLogger;
 use SplFileObject;
 
 class FileLoader implements LoaderInterface
@@ -14,16 +15,14 @@ class FileLoader implements LoaderInterface
 
     public function __construct(SplFileObject $file)
     {
+        $this->logger = new NullLogger();
         $this->file = $file;
     }
 
     public function load($data, ContextInterface $context)
     {
         $r = $this->file->fwrite($data);
-
-        if (null !== $this->logger) {
-            $this->logger->debug(sprintf('Wrote %s bytes in %s', $r, $this->file->getBasename()));
-        }
+        $this->logger->debug('Write to file', ['data' => $data, 'filename' => $this->file->getBasename(), 'bytes' => $r]);
 
         return $r;
     }

--- a/src/Knp/ETL/Transformer/Doctrine/ObjectTransformer.php
+++ b/src/Knp/ETL/Transformer/Doctrine/ObjectTransformer.php
@@ -6,23 +6,22 @@ use Knp\ETL\TransformerInterface;
 use Knp\ETL\ContextInterface;
 use Doctrine\Common\Persistence\ManagerRegistry;
 use Knp\ETL\Transformer\DataMap;
-use Psr\Log\LoggerAwareTrait;
+use Psr\Log\LoggerInterface;
 use Psr\Log\NullLogger;
 
 class ObjectTransformer implements TransformerInterface
 {
-    use LoggerAwareTrait;
-
     private $className;
     private $mapper;
     private $doctrine;
+    private $logger;
 
-    public function __construct($className, DataMap $mapper, ManagerRegistry $doctrine)
+    public function __construct($className, DataMap $mapper, ManagerRegistry $doctrine, LoggerInterface $logger = null)
     {
         $this->className = $className;
         $this->mapper = $mapper;
         $this->doctrine = $doctrine;
-        $this->logger = new NullLogger();
+        $this->logger = $logger ?: new NullLogger();
     }
 
     public function transform($data, ContextInterface $context)

--- a/src/Knp/ETL/Transformer/Doctrine/ObjectTransformer.php
+++ b/src/Knp/ETL/Transformer/Doctrine/ObjectTransformer.php
@@ -5,8 +5,9 @@ namespace Knp\ETL\Transformer\Doctrine;
 use Knp\ETL\TransformerInterface;
 use Knp\ETL\ContextInterface;
 use Doctrine\Common\Persistence\ManagerRegistry;
-use Psr\Log\LoggerAwareTrait;
 use Knp\ETL\Transformer\DataMap;
+use Psr\Log\LoggerAwareTrait;
+use Psr\Log\NullLogger;
 
 class ObjectTransformer implements TransformerInterface
 {
@@ -21,6 +22,7 @@ class ObjectTransformer implements TransformerInterface
         $this->className = $className;
         $this->mapper = $mapper;
         $this->doctrine = $doctrine;
+        $this->logger = new NullLogger();
     }
 
     public function transform($data, ContextInterface $context)
@@ -28,18 +30,14 @@ class ObjectTransformer implements TransformerInterface
         $this->mapper->verifyCount($data);
 
         $id = $context->getIdentifier();
-        if (null !== $this->logger) {
-            $this->logger->info(sprintf('Transforming data with id #%s', $id));
-        }
+        $this->logger->info('Transforming data', ['id' => $id]);
 
         $object = $this->doctrine->getRepository($this->className)->find($id);
 
         if (null === $object) {
             //TODO use a configurable factory here
             $object = new $this->className;
-            if (null !== $this->logger) {
-                $this->logger->info(sprintf('Creating new object "%s"', $this->className));
-            }
+            $this->logger->info('Creating new object', ['class' => $this->className]);
         }
 
         $this->mapper->set($data, $object);


### PR DESCRIPTION
Two points:
- If no logger is provided creating a NullLogger instance to have something to throw logs at is a good way to avoid littering your code with `if ($this->logger) { }`.
- Avoid to use `sprintf` in a log message to make it easier to grep, using the context part of a log is a good way to append metadata.
